### PR TITLE
fix: isPkgInstalled 'executable file not found in $PATH'

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -99,7 +99,7 @@ func parseSSHKeys() ([]string, error) {
 }
 
 func isPkgInstalled(pkg string) (bool, error) {
-	cmd := exec.Command(fmt.Sprintf("apt -qq list %s", pkg))
+	cmd := exec.Command("apt", "-qq", "list", pkg)
 	stdout, err := cmd.Output()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Hitting the `/packages/{name}` endpoint with a whitelisted package (like `nginx`), throws an error like
```
exec: \"apt -qq list nginx\": executable file not found in $PATH
```

This is fixed by separating the executable path and its args in the call to `exec.Command(...)`